### PR TITLE
Add Vagrantfile for test isolation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ hs_err_pid*
 build
 
 *.key
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision "shell", inline: <<PROV
+    echo $USER
+    apt-get install -y zip unzip \
+    && cat > ~vagrant/install_script.sh <<'EOS';
+      curl -s "https://get.sdkman.io" | bash \
+      && mkdir -p ~/.sdkman/etc \
+      && echo "HOME: " ~ \
+      && echo 'sdkman_auto_answer=true' > ~/.sdkman/etc/config \
+      && source ~/.sdkman/bin/sdkman-init.sh \
+      && yes | sdk install java 8u121 2>/dev/null \
+      && yes | sdk install gradle 3.1 2>/dev/null \
+      && echo "Provisioning complete. Now run 'vagrant ssh', cd to /vagrant, and run 'gradle test'"
+EOS
+    chown vagrant:vagrant ~vagrant/install_script.sh
+    sudo -iu vagrant source ~vagrant/install_script.sh
+PROV
+end


### PR DESCRIPTION
If you have Vagrant installed, you can now get a working Java + Gradle environment by simply running `vagrant up`

Used this to resolve nexmo/nexmo-java#40 as a "CANNOT REPRODUCE"